### PR TITLE
Construct developmental builds against future target instead of away from last release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 MANIFEST
 dist
 env
+.idea/

--- a/README.rst
+++ b/README.rst
@@ -42,12 +42,23 @@ as just the command to execute, for example ``git describe``. If it's a tuple, i
 have two elements, the first must be the command, and the second specifies how to
 adapt the version string to PEP440 and must one have one of the following values:
 
-``None``
+``None`` takes output of command as is:
+
     Do nothing, ignore PEP440 and accept that pip/setuptools will throw warnings
-``pep440-git-local``
-    Change ``"1.2.3-10-abc1234"``  to ``"1.2.3+git-10-abc1234"``
-``pep440-git-dev`` or ``pep440-git``
-    Change ``"1.2.3-10-abc1234"`` to ``"1.2.3.dev10"``
+
+``pep440-git-local`` moves number of commits and hash as local identifier:
+
+    * Change ``1.2.3`` to ``1.2.3``
+    * Change ``1.2.3-10-abc1234`` to ``1.2.3+git-10-abc1234``
+
+``pep440-git-dev`` or ``pep440-git`` moves number of commits into development release identifier and omits hash:
+
+    * Change ``1.2.3.dev`` to ``1.2.3.dev0``
+    * Change ``1.2.3.dev-N-abc1234`` to ``1.2.3.devN``
+    * Change ``1.2.3`` to ``1.2.3``
+    * Change ``1.2.3-0-abc1234`` to ``1.2.3``
+
+    Same works for pre-releases.
 
 installation
 ------------
@@ -74,4 +85,4 @@ Within a checkout of this repo:
     env/bin/pip install --editable .
     env/bin/python setup.py --version
 
-Make sure that you change the setup.py so that it actually makes use of setuptools-version-command.
+Make sure that you change the ``setup.py`` so that it actually makes use of setuptools-version-command.

--- a/README.rst
+++ b/README.rst
@@ -56,9 +56,13 @@ adapt the version string to PEP440 and must one have one of the following values
     * Change ``1.2.3.dev`` to ``1.2.3.dev0``
     * Change ``1.2.3.dev-N-abc1234`` to ``1.2.3.devN``
     * Change ``1.2.3`` to ``1.2.3``
-    * Change ``1.2.3-0-abc1234`` to ``1.2.3``
 
-    Same works for pre-releases.
+    In other works, it excepts you to create a separate ``.dev``-ending tag after each release, until you create a
+    release tag again. If you are not on tag, and don't have ``.dev``-ending tag, following will happen:
+
+    * Change ``1.2.3-N-abc1234`` to ``1.2.3.devN``
+
+    This is against PEP440-specification and supported only for backwards-compatibility. It may be removed in time.
 
 installation
 ------------

--- a/setuptools_version_command.py
+++ b/setuptools_version_command.py
@@ -84,10 +84,15 @@ def _apply_pep440(version, mode):
 
     elif mode in ['pep440-git', 'pep440-git-dev']:
         if version.endswith('.dev'):
-            return version + '0'  # in tag
+            return version + '0'  # on tag
         elif '.dev-' in version:
             parts = version.split('-')
             return parts[0] + parts[1]
+        elif '-' in version:
+            # XXX: This in not compliant with PEP440. It is supported here for backwards-compatibility
+            parts = version.split('-')
+            parts[-2] = 'dev' + parts[-2]
+            return '.'.join(parts[:-1])
         else:
             return version
 

--- a/setuptools_version_command.py
+++ b/setuptools_version_command.py
@@ -78,18 +78,20 @@ def _read_version(filename):
         return None
 
 def _apply_pep440(version, mode):
+
     if mode in ['pep440-git-local']:
         return version.replace('-', '+git-', 1).replace('-', '.')
 
     elif mode in ['pep440-git', 'pep440-git-dev']:
-        if '-' in version:
+        if version.endswith('.dev'):
+            return version + '0'  # in tag
+        elif '.dev-' in version:
             parts = version.split('-')
-            parts[-2] = 'dev' + parts[-2]
-            return '.'.join(parts[:-1])
+            return parts[0] + parts[1]
         else:
             return version
 
-    elif mode == None:
+    elif mode is None:
         return version
 
     else:


### PR DESCRIPTION
Library's current behavior is that *developmental versions* are constructed on top of last release (well, whatever tag was set). So, currently following happens:

    $ git describe
    1.2.3
    $ touch foo; git add foo; git commit -m "foo"
    $ git describe
    1.2.3-1-abc1234

Using `pep440-git-dev` mode this produces `1.2.3.dev1`.

However, PEP440 defines that developmental releases are built against future version (`1.2.3.dev1 < 1.2.3`). So, what we actually want is `1.2.4.dev0`.

I implemented that using an extra tag:

    $ git describe
    1.2.3
    $ git tag -a 1.2.4.dev -m "Building towards next version"  # indicates that we are working on developmental releases now
    $ git describe
    1.2.4.dev

This should produce `1.2.4.dev0`. Adding changes:

    $ touch foo; git add foo; git commit -m "foo"
    $ git describe
    1.2.4.dev-1-abc1234

This should produce `1.2.4.dev1`.

Then to release:

    $ git tag -a 1.3.0  # we added some features so we actually want to bump minor version
    $ git describe
    1.3.0

This should produce `1.3.0`.

In this PR, I harshly overrode the existing behavior, as it conflicts with PEP440 (if I read the spec correctly, that is!)